### PR TITLE
Update linking on Windows for upcoming version of Rtools.

### DIFF
--- a/src/Makevars.ucrt
+++ b/src/Makevars.ucrt
@@ -1,2 +1,9 @@
-PKG_CPPFLAGS = -I$(R_TOOLS_SOFT)/include/freetype2
-PKG_LIBS = -lfreetype -lharfbuzz -lfreetype -lpng -lz -lbz2
+
+ifeq (,$(shell pkg-config --version 2>/dev/null))
+  PKG_CPPFLAGS = -I$(R_TOOLS_SOFT)/include/freetype2
+  LIBBROTLI = $(or $(and $(wildcard $(R_TOOLS_SOFT)/lib/libbrotlidec.a),-lbrotlidec -lbrotlicommon),)
+  PKG_LIBS = -lfreetype $(LIBBROTLI) -lharfbuzz -lfreetype -lpng -lz -lbz2
+else
+  PKG_LIBS = $(shell pkg-config --libs freetype2)
+  PKG_CPPFLAGS = $(shell pkg-config --cflags freetype2)
+endif


### PR DESCRIPTION
This is to update the package to link with an upcoming version of Rtools on Windows, where freetype needs one more dependency. This also uses pkg-config, where available, which should reduce the need for such updates when Rtools is updated.